### PR TITLE
Evolve PDF-only cracker into modular SmartCrack framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,77 @@
-# PDF Password Cracker
+# SmartCrack
 
-This Python script attempts to crack the password of a protected PDF file using a wordlist. It leverages the `pikepdf` library for PDF manipulation and `termcolor` for colored terminal output.
+> Authorized use only. This tool is intended for legal security testing, incident response, and recovery workflows on assets you own or are explicitly authorized to assess.
 
-## Prerequisites
+SmartCrack is an intelligent Python framework that evolves the original PDF-only cracker into a modular automation layer over **Hashcat** and **John the Ripper**.
 
-Before running the script, ensure you have the following installed:
+## What was reused from the old PDF tool
 
-* **Python 3.x:** You can download it from [python.org](https://www.python.org/).
-* **pikepdf:** Install it using pip:
-    ```bash
-    pip install pikepdf
-    ```
-* **termcolor:** Install it using pip:
-    ```bash
-    pip install termcolor
-    ```
+The original repo implemented a dictionary-based PDF cracking workflow using `pikepdf` and a wordlist loop. SmartCrack preserves that core workflow concept (wordlist-first attack, local-only execution) while upgrading architecture and automation:
+
+- preserved dictionary-first cracking strategy
+- preserved PDF-centric workflow by adding automatic `pdf2john` extraction
+- preserved local/offline behavior
+- replaced hardcoded file paths and broad exception handling with safe modular execution
+
+## Features
+
+- Smart input detection (magic bytes + heuristics)
+- Automatic hash extraction via john helper tools (`pdf2john`, `zip2john`, `rar2john`, `office2john`, `ssh2john`, `7z2john.pl`)
+- Hash identification with confidence score + hashcat/john mapping
+- Automatic backend selection (Hashcat/John) with manual override
+- Wordlist profile management with persistence
+- Session save/history metadata
+- Rich + Typer modern CLI UX
+- Safety-first subprocess handling and explicit authorized-use warning
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Install external dependencies in your OS package manager:
+
+- `hashcat`
+- `john` (jumbo build preferred for extractor helpers)
 
 ## Usage
 
-1.  **Prepare a Wordlist:** Create a text file (e.g., `wordlist.txt`) containing a list of potential passwords, one password per line.
-2.  **Place the PDF:** Put the protected PDF file (e.g., `remote.pdf`) in the same directory as the Python script.
-3.  **Run the Script:** Execute the Python script.
-    ```bash
-    python pdf_cracker.py
-    ```
-4.  **Observe the Output:** The script will attempt each password from the wordlist and display the results in the terminal.
-    * If a password is incorrect, it will be printed in red.
-    * If a password is correct, it will be printed in green, and the script will terminate.
-5.  **Modify the script:**
-    * Change `"remote.pdf"` to the path of your pdf
-    * Change `"wordlist.txt"` to the path of your wordlist.
+```bash
+python -m smartcrack identify '$2b$12$.................................................'
+python -m smartcrack identify hashes.txt
+python -m smartcrack wordlists --add /path/to/rockyou.txt
+python -m smartcrack crack secret.pdf
+python -m smartcrack crack archive.zip --backend john
+python -m smartcrack crack dump.hash --wordlist /path/to/wordlist.txt
+```
 
-## Example
+Legacy command still works:
 
-Assuming you have a PDF file named `my_protected.pdf` and a wordlist named `passwords.txt`, and your python script is named `pdf_cracker.py`, you would:
+```bash
+python pdf_cracker.py crack secret.pdf
+```
 
-1.  Place `my_protected.pdf`, `passwords.txt`, and `pdf_cracker.py` in the same folder.
-2.  Run: `python pdf_cracker.py`
-3.  Modify the python script to:
-    ```python
-    import pikepdf
-    from termcolor import colored
+## Project structure
 
-    file = open("passwords.txt")
+```text
+smartcrack/
+  cli.py
+  detectors/
+  extractors/
+  identifiers/
+  crackers/
+  sessions/
+  config/
+  utils/
+  plugins/
+```
 
-    for password in file:
-        try:
-            with pikepdf.open("my_protected.pdf", password.strip()) as p:
-                print(colored("Password Found: {}".format(password), "green"))
-                break
-        except:
-            print(colored("Trying Password: {}".format(password), "red"), end="")
-            continue
-    ```
+## Next extensions
 
-## Important Notes
-
-* This script is intended for ethical use only. Do not use it to crack passwords for PDFs that you do not have authorization to access.
-* The success of this script depends on the strength and comprehensiveness of your wordlist.
-* For very strong passwords, this method may take a significant amount of time or may not be successful.
-* Consider using more advanced password cracking tools if you need to crack very strong passwords.
-* This is a dictionary attack. For stronger passwords, a brute force attack or other more sophisticated methods would be needed.
-
-## Contributing
-
-Feel free to contribute to this project by submitting pull requests or opening issues.
+- plugin registration API for new target formats
+- richer recommender with benchmark-driven scoring
+- Textual dashboard mode
+- distributed cracking orchestration

--- a/pdf_cracker.py
+++ b/pdf_cracker.py
@@ -1,19 +1,9 @@
-# Import necessary libraries
-import pikepdf  # For handling PDF files
-from termcolor import colored  # For printing colored output in the terminal
+"""Legacy compatibility launcher.
 
-# Open the wordlist file containing potential passwords
-file = open("wordlist.txt")
+This file keeps the original entry point but routes execution to SmartCrack.
+"""
 
-# Iterate through each password in the wordlist
-for password in file:
-    try:
-        # Attempt to open the encrypted PDF file with the current password
-        with pikepdf.open("remote.pdf", password.strip()) as p:
-            # If successful, print the found password in green and exit the loop
-            print(colored("Password Found: {}".format(password), "green"))
-            break
-    except:
-        # If the password is incorrect, print a red message and continue to the next password
-        print(colored("Trying Password: {}".format(password), "red"), end="")
-        continue
+from smartcrack.cli import app
+
+if __name__ == "__main__":
+    app(prog_name="smartcrack")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+typer>=0.12
+rich>=13.7
+pikepdf>=9.0

--- a/smartcrack/__main__.py
+++ b/smartcrack/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/smartcrack/cli.py
+++ b/smartcrack/cli.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+import uuid
+from pathlib import Path
+import typer
+from rich import print
+from rich.table import Table
+from .config.manager import ConfigManager
+from .config.models import CrackSession
+from .crackers.backends import BackendSelector
+from .crackers.engine import CrackingEngine
+from .detectors.input_detector import InputDetector
+from .extractors.john_extractors import JohnExtractorRegistry
+from .identifiers.hash_identifier import HashIdentifier
+from .recommender import recommend
+from .sessions.store import SessionStore
+
+app = typer.Typer(help="SmartCrack: intelligent wrapper around Hashcat + John")
+
+
+@app.command()
+def identify(input_value: str):
+    """Identify likely hash algorithm(s) for a raw hash string or file containing hashes."""
+    src = Path(input_value)
+    data = src.read_text().strip().splitlines()[0] if src.exists() else input_value
+    guesses = HashIdentifier().identify(data)
+    table = Table(title="Identification Results")
+    table.add_column("Algorithm")
+    table.add_column("Hashcat Mode")
+    table.add_column("John Format")
+    table.add_column("Confidence")
+    for g in guesses:
+        table.add_row(g.algorithm, g.hashcat_mode, g.john_format, f"{g.confidence:.2f}")
+    print(table)
+
+
+@app.command()
+def wordlists(add: str = typer.Option(None), use: str = typer.Option(None), show: bool = typer.Option(False)):
+    cm = ConfigManager()
+    cfg = cm.load()
+    if add:
+        p = Path(add)
+        if not p.exists():
+            raise typer.BadParameter(f"wordlist does not exist: {add}")
+        cfg.wordlists.saved[p.name] = str(p.resolve())
+        cfg.wordlists.active = str(p.resolve())
+        cm.save(cfg)
+        print(f"[green]Added and activated wordlist:[/green] {p}")
+    if use:
+        if use not in cfg.wordlists.saved:
+            raise typer.BadParameter(f"unknown saved wordlist key: {use}")
+        cfg.wordlists.active = cfg.wordlists.saved[use]
+        cm.save(cfg)
+        print(f"[green]Active wordlist:[/green] {cfg.wordlists.active}")
+    if show:
+        print(cfg.wordlists.saved)
+        print(f"active={cfg.wordlists.active}")
+
+
+@app.command()
+def crack(target: str, wordlist: str = typer.Option(None), backend: str = typer.Option("auto")):
+    detector = InputDetector()
+    detection = detector.detect(target)
+    print(f"[cyan]Detected[/cyan]: {detection.kind} ({detection.confidence:.2f}) - {detection.reason}")
+
+    hash_value = None
+    hash_file = None
+    if detection.kind in {"pdf", "zip", "rar", "office", "7z", "ssh"}:
+        extracted = JohnExtractorRegistry().extract(detection.kind, target)
+        if not extracted.ok:
+            raise typer.Exit(f"Extraction failed: {extracted.error}")
+        hash_value = extracted.hash_value
+        hash_file = Path(f".smartcrack_{Path(target).name}.hash")
+        hash_file.write_text(hash_value + "\n")
+    elif detection.kind == "raw-hash":
+        hash_value = target
+        hash_file = Path(".smartcrack_input.hash")
+        hash_file.write_text(hash_value + "\n")
+    else:
+        p = Path(target)
+        if p.exists():
+            hash_file = p
+            hash_value = p.read_text().strip().splitlines()[0]
+        else:
+            raise typer.Exit("Unsupported input target")
+
+    guesses = HashIdentifier().identify(hash_value)
+    if not guesses:
+        raise typer.Exit("Could not identify hash")
+    best = guesses[0]
+    selected = BackendSelector().select(best.hashcat_mode, best.john_format, prefer=backend)
+
+    cm = ConfigManager()
+    cfg = cm.load()
+    wl = wordlist or cfg.wordlists.active
+    if not wl:
+        print("[yellow]No active wordlist configured. Use smartcrack wordlists --add /path/to/list.txt[/yellow]")
+
+    for hint in recommend(detection.kind, best.algorithm):
+        print(f"[magenta]Hint:[/magenta] {hint}")
+
+    result = CrackingEngine().run(selected.command, str(hash_file), wordlist=wl)
+    print(result.stdout)
+    if result.stderr:
+        print(f"[red]{result.stderr}[/red]")
+
+    sess = CrackSession(session_id=str(uuid.uuid4()), input_path=target, target_type=detection.kind, backend=selected.backend, command=selected.command, status="completed" if result.returncode == 0 else "failed")
+    SessionStore().save(sess)
+
+
+def main():
+    app()
+
+if __name__ == "__main__":
+    main()

--- a/smartcrack/config/manager.py
+++ b/smartcrack/config/manager.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from .models import AppConfig, WordlistConfig
+
+
+class ConfigManager:
+    def __init__(self, path: Path | None = None):
+        self.path = path or AppConfig().config_path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load(self) -> AppConfig:
+        if not self.path.exists():
+            return AppConfig(config_path=self.path)
+        data = json.loads(self.path.read_text())
+        wl = WordlistConfig(active=data.get("wordlists", {}).get("active"), saved=data.get("wordlists", {}).get("saved", {}))
+        return AppConfig(default_backend=data.get("default_backend", "auto"), wordlists=wl, config_path=self.path)
+
+    def save(self, config: AppConfig) -> None:
+        payload = {
+            "default_backend": config.default_backend,
+            "wordlists": {"active": config.wordlists.active, "saved": config.wordlists.saved},
+        }
+        self.path.write_text(json.dumps(payload, indent=2))

--- a/smartcrack/config/models.py
+++ b/smartcrack/config/models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class WordlistConfig:
+    active: Optional[str] = None
+    saved: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AppConfig:
+    default_backend: str = "auto"
+    wordlists: WordlistConfig = field(default_factory=WordlistConfig)
+    config_path: Path = Path.home() / ".smartcrack" / "config.json"
+
+
+@dataclass
+class CrackSession:
+    session_id: str
+    input_path: str
+    target_type: str
+    backend: str
+    command: List[str]
+    status: str = "created"
+    discovered_password: Optional[str] = None

--- a/smartcrack/crackers/backends.py
+++ b/smartcrack/crackers/backends.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from shutil import which
+from typing import List
+
+
+@dataclass
+class CrackCommand:
+    backend: str
+    command: List[str]
+
+
+class BackendSelector:
+    def available(self) -> dict:
+        return {"hashcat": bool(which("hashcat")), "john": bool(which("john"))}
+
+    def select(self, hashcat_mode: str, john_format: str, prefer: str = "auto") -> CrackCommand:
+        avail = self.available()
+        if prefer == "hashcat" and avail["hashcat"]:
+            return CrackCommand("hashcat", ["hashcat", "-m", hashcat_mode])
+        if prefer == "john" and avail["john"]:
+            return CrackCommand("john", ["john", f"--format={john_format}"])
+        if avail["hashcat"]:
+            return CrackCommand("hashcat", ["hashcat", "-m", hashcat_mode])
+        if avail["john"]:
+            return CrackCommand("john", ["john", f"--format={john_format}"])
+        raise RuntimeError("No cracking backend found. Install hashcat and/or john.")

--- a/smartcrack/crackers/engine.py
+++ b/smartcrack/crackers/engine.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from ..utils.subprocess_utils import safe_run
+
+
+class CrackingEngine:
+    def run(self, base_cmd: list[str], hash_file: str, wordlist: str | None = None, extra: list[str] | None = None):
+        cmd = list(base_cmd)
+        if wordlist:
+            if cmd[0] == "hashcat":
+                cmd.extend([hash_file, wordlist])
+            else:
+                cmd.extend([f"--wordlist={wordlist}", hash_file])
+        else:
+            cmd.append(hash_file)
+        if extra:
+            cmd.extend(extra)
+        return safe_run(cmd)

--- a/smartcrack/detectors/input_detector.py
+++ b/smartcrack/detectors/input_detector.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+@dataclass
+class DetectionResult:
+    kind: str
+    confidence: float
+    reason: str
+
+
+class InputDetector:
+    MAGIC = {
+        b"%PDF-": "pdf",
+        b"PK\x03\x04": "zip",
+        b"Rar!\x1a\x07": "rar",
+        b"7z\xbc\xaf'\x1c": "7z",
+    }
+
+    HASH_PATTERNS = [
+        ("bcrypt", re.compile(r"^\$2[aby]\$\d{2}\$.{53}$")),
+        ("ntlm", re.compile(r"^[A-Fa-f0-9]{32}$")),
+        ("sha1", re.compile(r"^[A-Fa-f0-9]{40}$")),
+        ("sha256", re.compile(r"^[A-Fa-f0-9]{64}$")),
+        ("md5", re.compile(r"^[A-Fa-f0-9]{32}$")),
+        ("jwt", re.compile(r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$")),
+    ]
+
+    def detect(self, target: str) -> DetectionResult:
+        p = Path(target)
+        if p.exists() and p.is_file():
+            head = p.read_bytes()[:16]
+            for sig, kind in self.MAGIC.items():
+                if head.startswith(sig):
+                    return DetectionResult(kind=kind, confidence=0.98, reason=f"magic bytes matched {kind}")
+            lower = p.suffix.lower()
+            if lower in {".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx"}:
+                return DetectionResult(kind="office", confidence=0.70, reason="office extension heuristic")
+            if "shadow" in p.name:
+                return DetectionResult(kind="linux-shadow", confidence=0.70, reason="filename heuristic")
+            return DetectionResult(kind="unknown-file", confidence=0.30, reason="unrecognized file signature")
+
+        for kind, pattern in self.HASH_PATTERNS:
+            if pattern.match(target.strip()):
+                return DetectionResult(kind="raw-hash", confidence=0.95, reason=f"string pattern matched {kind}")
+
+        return DetectionResult(kind="unknown", confidence=0.10, reason="no heuristics matched")

--- a/smartcrack/extractors/john_extractors.py
+++ b/smartcrack/extractors/john_extractors.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from shutil import which
+from typing import Dict
+from ..utils.subprocess_utils import safe_run
+
+
+@dataclass
+class ExtractResult:
+    ok: bool
+    hash_value: str = ""
+    extractor: str = ""
+    error: str = ""
+
+
+class JohnExtractorRegistry:
+    EXTRACTOR_MAP: Dict[str, str] = {
+        "pdf": "pdf2john",
+        "zip": "zip2john",
+        "rar": "rar2john",
+        "office": "office2john",
+        "ssh": "ssh2john",
+        "7z": "7z2john.pl",
+    }
+
+    def extract(self, input_type: str, file_path: str) -> ExtractResult:
+        extractor = self.EXTRACTOR_MAP.get(input_type)
+        if not extractor:
+            return ExtractResult(ok=False, error=f"No extractor mapped for {input_type}")
+        if not which(extractor):
+            return ExtractResult(ok=False, extractor=extractor, error=f"{extractor} not installed")
+
+        completed = safe_run([extractor, str(Path(file_path))])
+        if completed.returncode != 0:
+            return ExtractResult(ok=False, extractor=extractor, error=completed.stderr.strip() or "extractor failed")
+        first_line = (completed.stdout or "").splitlines()[0] if completed.stdout else ""
+        return ExtractResult(ok=bool(first_line), extractor=extractor, hash_value=first_line, error="" if first_line else "empty extraction output")

--- a/smartcrack/identifiers/hash_identifier.py
+++ b/smartcrack/identifiers/hash_identifier.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class HashGuess:
+    algorithm: str
+    hashcat_mode: str
+    john_format: str
+    confidence: float
+
+
+class HashIdentifier:
+    RULES = [
+        ("bcrypt", re.compile(r"^\$2[aby]\$"), "3200", "bcrypt", 0.99),
+        ("md5", re.compile(r"^[A-Fa-f0-9]{32}$"), "0", "raw-md5", 0.70),
+        ("ntlm", re.compile(r"^[A-Fa-f0-9]{32}$"), "1000", "nt", 0.80),
+        ("sha1", re.compile(r"^[A-Fa-f0-9]{40}$"), "100", "raw-sha1", 0.95),
+        ("sha256", re.compile(r"^[A-Fa-f0-9]{64}$"), "1400", "raw-sha256", 0.95),
+        ("jwt-hs256", re.compile(r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$"), "16500", "HMAC-SHA256", 0.65),
+        ("pdf", re.compile(r"\$pdf\$"), "10400", "pdf", 0.98),
+        ("zip", re.compile(r"\$pkzip\$"), "17200", "zip", 0.98),
+    ]
+
+    def identify(self, hash_input: str) -> List[HashGuess]:
+        guesses = []
+        txt = hash_input.strip()
+        for algo, rule, hmode, jfmt, conf in self.RULES:
+            if rule.search(txt):
+                guesses.append(HashGuess(algo, hmode, jfmt, conf))
+        return sorted(guesses, key=lambda g: g.confidence, reverse=True)

--- a/smartcrack/recommender.py
+++ b/smartcrack/recommender.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+def recommend(target_type: str, identified_algo: str) -> list[str]:
+    hints = []
+    if target_type in {"pdf", "zip", "rar", "office"}:
+        hints.append("Start with dictionary + best64.rule for document-based targets.")
+    if identified_algo in {"ntlm", "md5", "sha1", "sha256"}:
+        hints.append("Try mask attack for common patterns like ?u?l?l?l?l?d?d.")
+    if identified_algo == "bcrypt":
+        hints.append("Prefer focused wordlists/rules due to bcrypt computational cost.")
+    if not hints:
+        hints.append("Begin with dictionary attack, then escalate to hybrid and masks.")
+    return hints

--- a/smartcrack/sessions/store.py
+++ b/smartcrack/sessions/store.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from ..config.models import CrackSession
+
+
+class SessionStore:
+    def __init__(self, base: Path | None = None):
+        self.base = base or Path.home() / ".smartcrack" / "sessions"
+        self.base.mkdir(parents=True, exist_ok=True)
+
+    def save(self, s: CrackSession):
+        path = self.base / f"{s.session_id}.json"
+        path.write_text(json.dumps(s.__dict__, indent=2))
+
+    def list_sessions(self):
+        return sorted(self.base.glob("*.json"))

--- a/smartcrack/utils/subprocess_utils.py
+++ b/smartcrack/utils/subprocess_utils.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+import subprocess
+
+def safe_run(command: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True, check=False)


### PR DESCRIPTION
### Motivation
- Evolve the existing single-file PDF dictionary cracker into a reusable, extensible framework to support many common cracking targets and workflows.
- Preserve the original dictionary-first PDF workflow and local-only behavior while removing hardcoded paths and brittle exception handling.
- Provide an automated, intelligent orchestration layer over `hashcat` and `john` to reduce manual steps and enable future plugin/UX improvements.

### Description
- Added a new `smartcrack` package with a modern CLI (`identify`, `crack`, `wordlists`) implemented in `smartcrack/cli.py` using `Typer`/`Rich` and a `__main__` entrypoint.
- Implemented modular components: input detection (`smartcrack/detectors/input_detector.py`), hash identification (`smartcrack/identifiers/hash_identifier.py`), extractor orchestration for John helpers (`smartcrack/extractors/john_extractors.py`), backend selection (`smartcrack/crackers/backends.py`), and a cracking engine wrapper (`smartcrack/crackers/engine.py`).
- Added configuration persistence (`smartcrack/config/models.py`, `smartcrack/config/manager.py`), session storage (`smartcrack/sessions/store.py`), a safe subprocess helper (`smartcrack/utils/subprocess_utils.py`), and a simple recommendation helper (`smartcrack/recommender.py`).
- Preserved the original entrypoint by converting `pdf_cracker.py` into a compatibility launcher that routes to the new CLI, updated `README.md`, and added `requirements.txt` listing `typer`, `rich`, and `pikepdf`.

### Testing
- Ran static/bytecode checks with `python -m py_compile pdf_cracker.py smartcrack/*.py smartcrack/*/*.py` which completed successfully. (✅)
- Attempted to run the CLI (`python -m smartcrack --help` and `python -m smartcrack identify <hash>`), but execution failed due to missing runtime dependency `typer` (`ModuleNotFoundError`) because `pip install -r requirements.txt` could not complete in this environment (package index/network blocked `403 Forbidden`). (⚠️)
- Note: runtime integration with external tools (`pdf2john`, `zip2john`, `hashcat`, `john`) was not executed here and will require those binaries installed on the host for end-to-end verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df94898a4832b8f75fd5d7064a339)